### PR TITLE
Swap gap for right margins as lightning doesnt like gap

### DIFF
--- a/src/components/Card.module.scss
+++ b/src/components/Card.module.scss
@@ -2,6 +2,7 @@
   width: 250px;
   height: 350px;
   border-radius: 20px;
+  margin-right: 2rem;
   /* background: #3b3c40a1; */
   transition: transform 0.5s cubic-bezier(0.175, 0.885, 0.32, 1.275),
     background 0.5s ease, box-shadow 0.5s ease;

--- a/src/components/Home.module.scss
+++ b/src/components/Home.module.scss
@@ -19,6 +19,5 @@
   flex-wrap: wrap;
   justify-content: center;
   margin: 0px 20px 130px;
-  gap: 2rem;
   margin-top: 1.5rem;
 }


### PR DESCRIPTION
Lightning doesn't display gap properly so we'll use margin-right on the cards instead.